### PR TITLE
Add manufacturer field to item. Add manufacturer column to CategoryTable

### DIFF
--- a/components/CategoryTable.module.scss
+++ b/components/CategoryTable.module.scss
@@ -82,15 +82,19 @@
 
 .ItemName {
   font-weight: 700;
-  width: 25%;
+  width: 15%;
 
   a {
     text-decoration: underline;
   }
 }
 
+.ItemManufacturer {
+  width: 13%;
+}
+
 .ItemDescription {
-  width: 42%;
+  width: 33%;
 }
 
 .ItemPrice {
@@ -99,7 +103,7 @@
 }
 
 .ItemWorn {
-  width: 42px;
+  width: 30px;
   text-align: right;
 }
 

--- a/components/CategoryTable.tsx
+++ b/components/CategoryTable.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export const CategoryTable: FC<Props> = ({ data, compact }) => {
   const { category, items } = data;
-
+  
   return (
     <div className={styles.CategoryTable}>
       <div className={styles.CategoryHeader}>
@@ -39,6 +39,7 @@ export const CategoryTable: FC<Props> = ({ data, compact }) => {
                   item.name
                 )}
               </div>
+              <div className={styles.ItemManufacturer}>{item.manufacturer}</div>
               <div className={styles.ItemDescription}>{item.product_name}</div>
               <div className={styles.ItemPrice}>
                 {item.price &&

--- a/types/item.ts
+++ b/types/item.ts
@@ -10,6 +10,7 @@ export interface BaseItem {
     price?: string;
     product_url?: string;
     notes?: string;
+    manufacturer?: string;
 }
 
 export interface Item extends BaseItem {
@@ -58,5 +59,6 @@ export enum ItemConstants {
     name = 200,
     product_name = 500,
     notes = 500,
-    product_url = 500
+    product_url = 500,
+    manufacturer = 200
 }


### PR DESCRIPTION
Updates `Item` type with the `manufacturer` field and adds a column in the pack view.

I adjusted the column widths in the CategoryTable to make room for the new one. Eventually it might be good to migrate this to a semantic HTML <table>.